### PR TITLE
Create RemoveNotePad.ps1

### DIFF
--- a/RemoveNotePad.ps1
+++ b/RemoveNotePad.ps1
@@ -1,0 +1,7 @@
+If ((Get-appxpackage -allusers Microsoft.WindowsNotepad).Status -eq "OK")
+{
+	$Notepad = (Get-appxpackage -allusers Microsoft.WindowsNotepad).PackageFullName
+Remove-AppxPackage -Package $Notepad -AllUsers 
+}else{
+	write-host = "NotePad is Already Gone"
+}


### PR DESCRIPTION
A Simple Powershell Script to check for the default NotePad in Windows and remove it if present.